### PR TITLE
Add users management page with modal

### DIFF
--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -9,6 +9,12 @@
                 <span class="sidebar-text">Dashboard</span>
             </a>
         </li>
+        <li>
+            <a href="users.php" class="sidebar-link">
+                <i class="bx bx-user"></i>
+                <span class="sidebar-text">Users</span>
+            </a>
+        </li>
         <li class="sidebar-dropdown">
             <button type="button" class="sidebar-link sidebar-dropdown-toggle">
                 <i class="bx bx-group"></i>

--- a/users.php
+++ b/users.php
@@ -1,0 +1,127 @@
+<?php
+session_start();
+
+// Check if user is logged in
+if(!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header("Location: login.php");
+    exit;
+}
+?>
+<?php include 'includes/common-header.php'; ?>
+
+<div id="adminPanel">
+    <!-- Sidebar -->
+    <?php include 'includes/sidebar.php'; ?>
+
+    <!-- Topbar -->
+    <?php include 'includes/topbar.php'; ?>
+
+    <!-- Main Content -->
+    <main class="main-content">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="mb-0">Users</h1>
+            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addUserModal">
+                <i class="bx bx-user-plus me-1"></i> Add User
+            </button>
+        </div>
+
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-striped align-middle mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">#</th>
+                                <th scope="col">Full Name</th>
+                                <th scope="col">Email</th>
+                                <th scope="col">Role</th>
+                                <th scope="col" class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <th scope="row">1</th>
+                                <td>Priya Sharma</td>
+                                <td>priya.sharma@example.com</td>
+                                <td><span class="badge bg-primary">Admin</span></td>
+                                <td class="text-end">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary me-2" title="Edit">
+                                        <i class="bx bx-edit-alt"></i>
+                                    </button>
+                                    <button type="button" class="btn btn-sm btn-outline-danger" title="Delete">
+                                        <i class="bx bx-trash"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">2</th>
+                                <td>Rohit Verma</td>
+                                <td>rohit.verma@example.com</td>
+                                <td><span class="badge bg-success">Manager</span></td>
+                                <td class="text-end">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary me-2" title="Edit">
+                                        <i class="bx bx-edit-alt"></i>
+                                    </button>
+                                    <button type="button" class="btn btn-sm btn-outline-danger" title="Delete">
+                                        <i class="bx bx-trash"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </main>
+</div>
+
+<!-- Add User Modal -->
+<div class="modal fade" id="addUserModal" tabindex="-1" aria-labelledby="addUserModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addUserModalLabel">Add New User</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="mb-3">
+                        <label for="fullName" class="form-label">Full Name</label>
+                        <input type="text" class="form-control" id="fullName" placeholder="Enter full name">
+                    </div>
+                    <div class="mb-3">
+                        <label for="emailAddress" class="form-label">Email address</label>
+                        <input type="email" class="form-control" id="emailAddress" placeholder="Enter email">
+                    </div>
+                    <fieldset class="mb-3">
+                        <legend class="col-form-label pt-0">Role</legend>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="userRole" id="roleAdmin" value="admin" checked>
+                            <label class="form-check-label" for="roleAdmin">
+                                Admin
+                            </label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="userRole" id="roleManager" value="manager">
+                            <label class="form-check-label" for="roleManager">
+                                Manager
+                            </label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="userRole" id="roleAgent" value="agent">
+                            <label class="form-check-label" for="roleAgent">
+                                Agent
+                            </label>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary">Save User</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php include 'includes/common-footer.php'; ?>


### PR DESCRIPTION
## Summary
- add a Users navigation link in the sidebar
- create a Users page with a Bootstrap table listing example users and action buttons
- include an Add User modal with fields and role radio buttons for future RBAC setup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e643f58768832abe1100ae6e114c8c