### PR TITLE
Enable email-based user authentication

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS users (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     full_name VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL DEFAULT '',
     role ENUM('admin', 'manager', 'agent') NOT NULL DEFAULT 'agent',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
@@ -25,5 +26,37 @@ SQL;
 
 if (!$mysqli->query($createUsersTable)) {
     die('Failed to ensure users table exists: ' . $mysqli->error);
+}
+
+// Ensure password_hash column exists for legacy installations
+$passwordColumnCheck = $mysqli->query("SHOW COLUMNS FROM users LIKE 'password_hash'");
+if ($passwordColumnCheck) {
+    if ($passwordColumnCheck->num_rows === 0) {
+        if (!$mysqli->query("ALTER TABLE users ADD COLUMN password_hash VARCHAR(255) NOT NULL DEFAULT '' AFTER email")) {
+            die('Failed to add password column: ' . $mysqli->error);
+        }
+    }
+    $passwordColumnCheck->free();
+} else {
+    die('Failed to inspect users table: ' . $mysqli->error);
+}
+
+// Seed a default admin user if no users exist yet
+$existingUsers = $mysqli->query('SELECT COUNT(*) AS user_count FROM users');
+if ($existingUsers) {
+    $row = $existingUsers->fetch_assoc();
+    if ((int) ($row['user_count'] ?? 0) === 0) {
+        $defaultPasswordHash = password_hash('admin123', PASSWORD_DEFAULT);
+        $stmt = $mysqli->prepare('INSERT INTO users (full_name, email, password_hash, role) VALUES (?, ?, ?, ?)');
+        if ($stmt) {
+            $defaultName = 'Administrator';
+            $defaultEmail = 'admin@example.com';
+            $defaultRole = 'admin';
+            $stmt->bind_param('ssss', $defaultName, $defaultEmail, $defaultPasswordHash, $defaultRole);
+            $stmt->execute();
+            $stmt->close();
+        }
+    }
+    $existingUsers->free();
 }
 ?>

--- a/includes/topbar.php
+++ b/includes/topbar.php
@@ -1,9 +1,10 @@
+<?php $displayName = $_SESSION['username'] ?? 'User'; ?>
 <header class="topbar">
     <div class="topbar-left">
         <button class="toggle-btn" onclick="toggleSidebar()">
             <i class="bx bx-menu"></i>
         </button>
-        <h5 class="mb-0 ms-3">Welcome back, <?php echo $_SESSION['username']; ?>!</h5>
+        <h5 class="mb-0 ms-3">Welcome back, <?php echo htmlspecialchars($displayName); ?>!</h5>
     </div>
     <div class="topbar-right">
         <div class="notification-icon">
@@ -14,7 +15,7 @@
             <div class="user-avatar dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
                 <i class="bx bx-user"></i>
             </div>
-            <span class="user-name"><?php echo ucfirst($_SESSION['username']); ?></span>
+            <span class="user-name"><?php echo htmlspecialchars(ucfirst($displayName)); ?></span>
             <ul class="dropdown-menu dropdown-menu-end">
                 <li><a class="dropdown-item" href="#profile"><i class="bx bx-user-circle"></i> Profile</a></li>
                 <li><a class="dropdown-item" href="#settings"><i class="bx bx-cog"></i> Settings</a></li>


### PR DESCRIPTION
## Summary
- add password hashing support and default admin seeding to the users table setup
- update the Add/Edit User flows to capture passwords with visibility toggles and optional updates
- switch login to authenticate against stored email/password credentials and show sanitized user info in the header

## Testing
- php -l includes/config.php
- php -l login.php
- php -l users.php
- php -l includes/topbar.php

------
https://chatgpt.com/codex/tasks/task_e_68e64e3e7e2c832a9866b89b60f2a981