### PR TITLE
Align topbar avatar styling with theme and adopt Montserrat font

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');
+
+:root {
+    --theme-color: #004526;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -5,14 +11,14 @@
 }
 
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-family: 'Montserrat', sans-serif;
     overflow-x: hidden;
     background: #f8f9fa;
 }
 
 .btn-primary {
-    background-color: #004526;
-    border-color: #004526;
+    background-color: var(--theme-color);
+    border-color: var(--theme-color);
     color: #fff;
     transition: all 0.2s ease-in-out;
 }
@@ -29,15 +35,15 @@ body {
 
 .btn-primary:disabled,
 .btn-primary.disabled {
-    background-color: #004526;
-    border-color: #004526;
+    background-color: var(--theme-color);
+    border-color: var(--theme-color);
     opacity: 0.65;
 }
 
 .form-control:focus {
     outline: none;
     box-shadow: none !important;
-    border: 1px solid #004526 !important;
+    border: 1px solid var(--theme-color) !important;
     transition: border-color 0.25s ease-in-out;
 }
 
@@ -305,7 +311,7 @@ body {
 }
 
 .toggle-btn:hover {
-    color: #004526;
+    color: var(--theme-color);
 }
 
 .topbar-right {
@@ -323,7 +329,7 @@ body {
 }
 
 .notification-icon:hover {
-    color: #004526;
+    color: var(--theme-color);
 }
 
 .badge-notification {
@@ -348,12 +354,16 @@ body {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #004526 0%, #764ba2 100%);
+    background-color: var(--theme-color);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: white;
+    color: #ffffff;
     cursor: pointer;
+}
+
+.user-avatar i {
+    color: inherit;
 }
 
 .user-name {

--- a/includes/topbar.php
+++ b/includes/topbar.php
@@ -12,8 +12,8 @@
             <span class="badge-notification">3</span>
         </div>
         <div class="user-profile dropdown">
-            <div class="user-avatar dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-                <i class="bx bx-user"></i>
+            <div class="user-avatar dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Open user menu">
+                <i class="bx bx-user" aria-hidden="true"></i>
             </div>
             <span class="user-name"><?php echo htmlspecialchars(ucfirst($displayName)); ?></span>
             <ul class="dropdown-menu dropdown-menu-end">


### PR DESCRIPTION
## Summary
- import the Montserrat typeface globally and hook core elements to the shared theme color variable
- refresh topbar avatar styling so the icon inherits the theme color palette without gradients
- improve accessibility of the user menu trigger with an aria label and hidden indicator

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e658179244832a9a30d336a13e33fd